### PR TITLE
Always use g_poll; try .dylib explicitly; avoid -march=i486 on Snow Leopard

### DIFF
--- a/build-aux/sync-builtins.m4
+++ b/build-aux/sync-builtins.m4
@@ -6,6 +6,7 @@ AC_DEFUN([GST_C_SYNC_BUILTINS], [
                  gst_cv_have_sync_fetch_and_add, [
     save_CFLAGS="$CFLAGS"
     case $host in
+      i386-apple-darwin10.8.0) true ;; # x86-64 masquerades as this??
       i?86-*-*) CFLAGS="$CFLAGS -march=i486" ;;
     esac
     AC_LINK_IFELSE([AC_LANG_PROGRAM([[int foovar = 0;]], [[

--- a/libgst/cint.c
+++ b/libgst/cint.c
@@ -498,6 +498,18 @@ dld_open (const char *filename)
   handle = lt_dlopen (filename);
   if (!handle)
     handle = lt_dlopenext (filename);
+  if (!handle)
+    {
+      /* For some reason, lt_dlopenext on OS X doesn't try ".dylib" as
+	 a possible extension, so we're left with trying it here. */
+      char *full_filename = alloca(strlen(filename) + 7 /* ".dylib" + NUL byte */);
+      if (full_filename == NULL)
+	return (NULL);
+      strcpy(full_filename, filename);
+      strcat(full_filename, ".dylib");
+      handle = lt_dlopen (full_filename);
+    }
+
   if (handle)
     {
       initModule = lt_dlsym (handle, "gst_initModule");

--- a/packages/glib/gst-glib.c
+++ b/packages/glib/gst-glib.c
@@ -186,11 +186,7 @@ main_loop_poll (int ms)
     timeout = ms;
 
   g_main_context_release (context);
-#ifdef G_WIN32_MSG_HANDLE
   g_poll (fds, nfds, timeout);
-#else
-  poll ((struct pollfd *) fds, nfds, timeout);
-#endif
   return g_main_context_check (context, maxprio, fds, nfds);
 }
 


### PR DESCRIPTION
Hi Paolo,

I've been dusting off my old SDL/Cairo code, and in the process discovering problems with building GNU smalltalk for OS X Snow Leopard.
- in GLib, if poll() is used, the linker complains about a missing rpl_poll()
- when detecting synchronisation primitives, -march=i486 on an x86_64 causes lots of confusion. I don't know why $host claims the machine is an i386 to begin with.
- lt_dlopenext doesn't try ".dylib" for some reason! Weird.

The g_poll() patch seems uncontroversial.

The sync-builtins patch was a quick hatchet job. Is there a cleaner or better way to do this? Without this patch or something similar, ./configure won't complete on my machine.

The ".dylib" patch works, but I wonder two things (1) is there a string concat helper somewhere in the code that I should be using instead of alloca/strcpy/strcat? and (2) should the .dylib block be #ifdef'd for OS X only?
