### PR TITLE
fix for http://smalltalk.gnu.org/project/issue/646

### DIFF
--- a/libgst/cint.c
+++ b/libgst/cint.c
@@ -254,6 +254,8 @@ static const char *c_type_name[] = {
   "wchar_t *",			/* CDATA_WSTRING */
   "wchar_t *",			/* CDATA_WSTRING_OUT */
   "char *",			/* CDATA_SYMBOL_OUT */
+  "long long",			/* CDATA_LONGLONG */
+  "unsigned long long", 	/* CDATA_ULONGLONG */
 };
 
 /* The errno on output from a callout */
@@ -440,10 +442,11 @@ my_opendir (const char *dir)
   return (result);
 }
 
-void 
+long long
 test_longlong (long long aVerylongInt)
 {
   printf ("Getting a long long 0x%llx\n", aVerylongInt);
+  return aVerylongInt;
 }
 
 void
@@ -1339,6 +1342,14 @@ c_to_smalltalk (cparam *result, OOP receiverOOP, OOP returnTypeOOP)
 
     case CDATA_ULONG:
       resultOOP = FROM_C_ULONG (result->u.longVal);
+      break;
+
+    case CDATA_LONGLONG:
+      resultOOP = FROM_C_LONGLONG (result->u.longLongVal);
+      break;
+
+    case CDATA_ULONGLONG:
+      resultOOP = FROM_C_ULONGLONG (result->u.longLongVal);
       break;
 
     case CDATA_STRING:

--- a/libgst/dict.inl
+++ b/libgst/dict.inl
@@ -274,6 +274,8 @@ static inline uint64_t to_c_uint_64 (OOP oop);
 
 #define TO_C_INT(integer)	to_c_int_32(integer)
 #define IS_C_INT(oop)		is_c_int_32(oop)
+#define FROM_C_LONGLONG(integ)	from_c_int_64(integ)
+#define FROM_C_ULONGLONG(integ)	from_c_uint_64(integ)
 
 #if SIZEOF_OOP == 4
 #define FROM_C_INT(integer)	FROM_C_LONG((intptr_t) (signed) integer)

--- a/tests/cobjects.ok
+++ b/tests/cobjects.ok
@@ -101,7 +101,7 @@ returned value is nil
 
 Execution begins...
 Getting a long long 0x100110012002
-returned value is nil
+returned value is '17596749520898'
 
 Execution begins...
 returned value is 'this is a test'

--- a/tests/cobjects.st
+++ b/tests/cobjects.st
@@ -121,7 +121,7 @@ Object extend [
     ]
 
     testLongLong: aLong [
-         <cCall: 'testLongLong' returning: #void args: #(#longLong)>
+         <cCall: 'testLongLong' returning: #longLong args: #(#longLong)>
     ]
 ]
 
@@ -129,7 +129,7 @@ Eval [ true testCallin: (CCallbackDescriptor for: [ :x | x printNl. 3 ]
        returning: #int withArgs: #(#string)) ]
 Eval [ nil testCString: (CString value: 'this is a test') ]
 
-Eval [ nil testLongLong: 16r100110012002. ^nil ]
+Eval [ ^(nil testLongLong: 16r100110012002) printString ]
 
 Eval [
     cObject := CCharType new.


### PR DESCRIPTION
Hello,

please pull the proposed fix for http://smalltalk.gnu.org/project/issue/646.

Thanks,
Regards,

Thomas

---

<pre>
2012-06-04  Thomas Girard  <thomas.g.girard@free.fr>
    * tests/cobjects.st: Adapt longLong test case, showing the issue#646.
    * tests/cobjects.ok: Regenerate.

libgst:
2012-06-04  Thomas Girard  <thomas.g.girard@free.fr>

    * libgst/dict.inl: Add FROM_C_LONGLONG and FROM_C_ULONGLONG macros.
    * libgst/cint.c: Add missing mappings from (unsigned) long long.
</pre>
